### PR TITLE
dragonboard-820c: create 32-bit machine configuration

### DIFF
--- a/conf/machine/dragonboard-820c-32.conf
+++ b/conf/machine/dragonboard-820c-32.conf
@@ -1,0 +1,21 @@
+#@TYPE: Machine
+#@NAME: dragonboard-820c-32
+#@DESCRIPTION: 32-bit Machine configuration for the DragonBoard 820c (96boards), with Qualcomm Snapdragon 820 APQ8096.
+
+require conf/machine/include/qcom-apq8096.inc
+
+MACHINE_FEATURES = "usbhost usbgadget alsa screen wifi bluetooth ext2"
+
+# Building 32-bit kernel is not supported.
+PREFERRED_PROVIDER_virtual/kernel = "linux-dummy"
+RDEPENDS_kernel-base = ""
+
+SERIAL_CONSOLE = "115200 ttyMSM0"
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+"
+
+QCOM_BOOTIMG_ROOTFS ?= "sde18"
+
+# UFS partitions setup with 4096 logical sector size
+EXTRA_IMAGECMD_ext4 += " -b 4096 "


### PR DESCRIPTION
This 32-bit machine is not intended to build 32-bit linux kernel,
so it uses "linux-dummy" for virtual/kernel provider, and doesn't
include the kernel into the rootfs image.

Signed-off-by: Pramod Gurav <pramod.gurav@linaro.org>